### PR TITLE
feat(product): 내 가게 상품 관리(CRUD) 기능 추가

### DIFF
--- a/src/main/java/kr/elroy/aigoya/product/api/ProductApi.java
+++ b/src/main/java/kr/elroy/aigoya/product/api/ProductApi.java
@@ -5,34 +5,53 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import kr.elroy.aigoya.product.dto.request.CreateProductRequest;
+import kr.elroy.aigoya.product.dto.request.UpdateProductRequest;
 import kr.elroy.aigoya.product.dto.response.ProductResponse;
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "상품 API", description = "상품 API")
-@RestController
-@Validated
-@RequestMapping("/v1/products")
+import java.util.List;
+
+@Tag(name = "상품 관리", description = "내 가게의 상품 관리 API (인증 필요)")
+@RequestMapping("/v1/stores/me/products")
 public interface ProductApi {
 
-    @Operation(summary = "상품 조회", description = "상품 정보를 조회합니다.")
-    @GetMapping("/{id}")
-    ProductResponse getProduct(
-            @Parameter(description = "상품 ID", required = true, example = "1")
-            @PathVariable
-            Long id
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "새 상품 등록")
+    ProductResponse createProduct(
+            @Parameter(hidden = true) @AuthenticationPrincipal(expression = "id") Long storeId,
+            @Valid @RequestBody CreateProductRequest request
     );
 
-    @Operation(summary = "상품 생성", description = "새로운 상품을 생성합니다.")
-    @PostMapping
-    ProductResponse createProduct(
-            @Valid
-            @RequestBody
-            CreateProductRequest request
+    @GetMapping
+    @Operation(summary = "내 가게의 모든 상품 목록 조회")
+    List<ProductResponse> getAllProducts(
+            @Parameter(hidden = true) @AuthenticationPrincipal(expression = "id") Long storeId
+    );
+
+    @GetMapping("/{productId}")
+    @Operation(summary = "특정 상품 정보 단일 조회")
+    ProductResponse getProduct(
+            @Parameter(hidden = true) @AuthenticationPrincipal(expression = "id") Long storeId,
+            @Parameter(description = "상품 ID", required = true, example = "1")
+            @PathVariable Long productId
+    );
+
+    @PutMapping("/{productId}")
+    @Operation(summary = "특정 상품 정보 수정")
+    ProductResponse updateProduct(
+            @Parameter(hidden = true) @AuthenticationPrincipal(expression = "id") Long storeId,
+            @PathVariable Long productId,
+            @Valid @RequestBody UpdateProductRequest request
+    );
+
+    @DeleteMapping("/{productId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "특정 상품 삭제")
+    void deleteProduct(
+            @Parameter(hidden = true) @AuthenticationPrincipal(expression = "id") Long storeId,
+            @PathVariable Long productId
     );
 }

--- a/src/main/java/kr/elroy/aigoya/product/controller/ProductController.java
+++ b/src/main/java/kr/elroy/aigoya/product/controller/ProductController.java
@@ -1,0 +1,48 @@
+package kr.elroy.aigoya.product.controller;
+
+import kr.elroy.aigoya.product.api.ProductApi;
+import kr.elroy.aigoya.product.domain.Product;
+import kr.elroy.aigoya.product.dto.request.CreateProductRequest;
+import kr.elroy.aigoya.product.dto.request.UpdateProductRequest;
+import kr.elroy.aigoya.product.dto.response.ProductResponse;
+import kr.elroy.aigoya.product.service.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class ProductController implements ProductApi {
+
+    private final ProductService productService;
+
+    @Override
+    public ProductResponse createProduct(Long storeId, CreateProductRequest request) {
+        Product createdProduct = productService.createProduct(storeId, request);
+        return ProductResponse.from(createdProduct);
+    }
+
+    @Override
+    public ProductResponse getProduct(Long storeId, Long productId) {
+        Product product = productService.getProduct(storeId, productId);
+        return ProductResponse.from(product);
+    }
+
+    @Override
+    public List<ProductResponse> getAllProducts(Long storeId) {
+        return productService.getProductsByStore(storeId).stream()
+                .map(ProductResponse::from)
+                .toList();
+    }
+
+    @Override
+    public ProductResponse updateProduct(Long storeId, Long productId, UpdateProductRequest request) {
+        Product updatedProduct = productService.updateProduct(storeId, productId, request);
+        return ProductResponse.from(updatedProduct);
+    }
+    @Override
+    public void deleteProduct(Long storeId, Long productId) {
+        productService.deleteProduct(storeId, productId);
+    }
+}

--- a/src/main/java/kr/elroy/aigoya/product/domain/OrderProduct.java
+++ b/src/main/java/kr/elroy/aigoya/product/domain/OrderProduct.java
@@ -1,24 +1,16 @@
-package kr.elroy.aigoya.product;
+package kr.elroy.aigoya.product.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import kr.elroy.aigoya.order.Order;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
-@Setter
 @Builder
 @Entity(name = "order_product")
 public class OrderProduct {
@@ -26,13 +18,17 @@ public class OrderProduct {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
-    @ManyToOne
-    @JoinColumn(name = "order_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
     private Order order;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
     private Product product;
 
     @Column(name = "quantity", nullable = false)
     private Integer quantity;
+
+    @Column(nullable = false)
+    private Long orderPrice;
 }

--- a/src/main/java/kr/elroy/aigoya/product/domain/Product.java
+++ b/src/main/java/kr/elroy/aigoya/product/domain/Product.java
@@ -1,23 +1,16 @@
-package kr.elroy.aigoya.product;
+package kr.elroy.aigoya.product.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import kr.elroy.aigoya.store.domain.Store;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
-@Setter
 @Builder
 @Entity(name = "product")
 public class Product {
@@ -31,6 +24,12 @@ public class Product {
     @Column(name = "price", nullable = false)
     private Long price;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id")
     private Store store;
+
+    public void updateInfo(String name, Long price) {
+        this.name = name;
+        this.price = price;
+    }
 }

--- a/src/main/java/kr/elroy/aigoya/product/dto/response/ProductResponse.java
+++ b/src/main/java/kr/elroy/aigoya/product/dto/response/ProductResponse.java
@@ -1,7 +1,7 @@
 package kr.elroy.aigoya.product.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import kr.elroy.aigoya.product.Product;
+import kr.elroy.aigoya.product.domain.Product;
 
 @Schema(description = "상품 응답 DTO")
 public record ProductResponse(

--- a/src/main/java/kr/elroy/aigoya/product/repository/ProductRepository.java
+++ b/src/main/java/kr/elroy/aigoya/product/repository/ProductRepository.java
@@ -1,0 +1,10 @@
+package kr.elroy.aigoya.product.repository;
+
+import kr.elroy.aigoya.product.domain.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+    List<Product> findByStoreId(Long storeId);
+}

--- a/src/main/java/kr/elroy/aigoya/product/service/ProductService.java
+++ b/src/main/java/kr/elroy/aigoya/product/service/ProductService.java
@@ -1,0 +1,68 @@
+package kr.elroy.aigoya.product.service;
+
+import kr.elroy.aigoya.product.repository.ProductRepository;
+import kr.elroy.aigoya.product.domain.Product;
+import kr.elroy.aigoya.product.dto.request.CreateProductRequest;
+import kr.elroy.aigoya.product.dto.request.UpdateProductRequest;
+import kr.elroy.aigoya.store.domain.Store;
+import kr.elroy.aigoya.store.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ProductService {
+
+    private final ProductRepository productRepository;
+    private final StoreRepository storeRepository;
+
+    public Product createProduct(Long storeId, CreateProductRequest request) {
+        Store store = storeRepository.findById(storeId).orElseThrow();
+        Product newProduct = Product.builder()
+                .name(request.name())
+                .price(request.price())
+                .store(store)
+                .build();
+        return productRepository.save(newProduct);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Product> getProductsByStore(Long storeId) {
+        return productRepository.findByStoreId(storeId);
+    }
+
+    @Transactional(readOnly = true)
+    public Product getProduct(Long storeId, Long productId) {
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new IllegalArgumentException("상품을 찾을 수 없습니다."));
+        if (!product.getStore().getId().equals(storeId)) {
+            throw new SecurityException("자신의 가게 상품만 조회할 수 있습니다.");
+        }
+
+        return product;
+    }
+
+    public Product updateProduct(Long storeId, Long productId, UpdateProductRequest request) {
+        Product product = productRepository.findById(productId).orElseThrow();
+        if (!product.getStore().getId().equals(storeId)) {
+            throw new SecurityException("자신의 가게 상품만 수정할 수 있습니다.");
+        }
+        product.updateInfo(request.name(), request.price());
+        return product;
+    }
+
+    public void deleteProduct(Long storeId, Long productId) {
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new IllegalArgumentException("상품을 찾을 수 없습니다."));
+
+        if (!product.getStore().getId().equals(storeId)) {
+            throw new SecurityException("자신의 가게 상품만 삭제할 수 있습니다.");
+        }
+
+        productRepository.delete(product);
+    }
+}


### PR DESCRIPTION
# <본문>
- 인증된 가게 주인이 자신의 상품을 관리할 수 있는 API를 구현합니다.

- 모든 엔드포인트는 `/v1/stores/me/products` 경로를 사용합니다.

## 구현된 기능
- 상품 등록 (Create)

- 내 가게의 전체 상품 목록 조회 (Read All)

- 특정 상품 상세 조회 (Read One by ID)

- 상품 정보 수정 (Update)

- 상품 삭제 (Delete)

## 아키텍처
- Product 모듈의 Entity, Repository, DTO, Service, API, Controller 계층을 모두 구현했습니다.

- Service 계층에 상품 소유권자(가게 주인)를 확인하는 보안 로직을 포함했습니다.