### PR TITLE
feat(analytics): 애널리틱스 API 명세 및 응답 DTO 정의

### DIFF
--- a/src/main/java/kr/elroy/aigoya/analytics/api/AnalyticsApi.java
+++ b/src/main/java/kr/elroy/aigoya/analytics/api/AnalyticsApi.java
@@ -1,0 +1,55 @@
+package kr.elroy.aigoya.analytics.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.elroy.aigoya.analytics.dto.response.DailySummaryResponse;
+import kr.elroy.aigoya.analytics.dto.response.HourlySalesResponse;
+import kr.elroy.aigoya.analytics.dto.response.MenuAnalysisResponse;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.time.LocalDate;
+
+@Tag(name = "애널리틱스", description = "내 가게의 데이터 분석 API (인증 필요)")
+@RequestMapping("/v1/stores/me/analytics")
+public interface AnalyticsApi {
+    @GetMapping("/daily-summary")
+    @Operation(summary = "일일 핵심 지표 요약", description = "특정 날짜의 총 매출, 거래 건수, 평균 객단가를 조회합니다.")
+    DailySummaryResponse getDailySummary(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal(expression = "id") Long storeId,
+            @Parameter(description = "조회할 날짜 (YYYY-MM-DD). 미입력 시 오늘 날짜.")
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    );
+
+    @GetMapping("/sales-by-hour")
+    @Operation(summary = "시간대별 매출 분석", description = "특정 날짜의 시간대별 매출 분포를 조회합니다.")
+    HourlySalesResponse getSalesByHour(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal(expression = "id") Long storeId,
+            @Parameter(description = "조회할 날짜 (YYYY-MM-DD). 미입력 시 오늘 날짜.")
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    );
+
+    @GetMapping("/menu-analysis")
+    @Operation(summary = "메뉴 분석 (인기/비인기)", description = "기간별 인기 또는 비인기 메뉴 순위를 조회합니다.")
+    MenuAnalysisResponse getMenuAnalysis(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal(expression = "id") Long storeId,
+
+            @Parameter(description = "분석 타입 (top: 인기, bottom: 비인기)", required = true, example = "top")
+            @RequestParam String type,
+
+            @Parameter(description = "조회 기간 (daily: 오늘, weekly: 이번 주)", required = true, example = "daily")
+            @RequestParam String period,
+
+            @Parameter(description = "조회할 메뉴 개수", example = "5")
+            @RequestParam(defaultValue = "5") int limit
+    );
+}

--- a/src/main/java/kr/elroy/aigoya/analytics/api/AnalyticsApi.java
+++ b/src/main/java/kr/elroy/aigoya/analytics/api/AnalyticsApi.java
@@ -3,6 +3,8 @@ package kr.elroy.aigoya.analytics.api;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.elroy.aigoya.analytics.dto.request.AnalysisPeriod;
+import kr.elroy.aigoya.analytics.dto.request.MenuAnalysisType;
 import kr.elroy.aigoya.analytics.dto.response.DailySummaryResponse;
 import kr.elroy.aigoya.analytics.dto.response.HourlySalesResponse;
 import kr.elroy.aigoya.analytics.dto.response.MenuAnalysisResponse;
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Tag(name = "애널리틱스", description = "내 가게의 데이터 분석 API (인증 필요)")
 @RequestMapping("/v1/stores/me/analytics")
@@ -29,7 +32,7 @@ public interface AnalyticsApi {
 
     @GetMapping("/sales-by-hour")
     @Operation(summary = "시간대별 매출 분석", description = "특정 날짜의 시간대별 매출 분포를 조회합니다.")
-    HourlySalesResponse getSalesByHour(
+    List<HourlySalesResponse> getSalesByHour(
             @Parameter(hidden = true)
             @AuthenticationPrincipal(expression = "id") Long storeId,
             @Parameter(description = "조회할 날짜 (YYYY-MM-DD). 미입력 시 오늘 날짜.")
@@ -39,17 +42,17 @@ public interface AnalyticsApi {
 
     @GetMapping("/menu-analysis")
     @Operation(summary = "메뉴 분석 (인기/비인기)", description = "기간별 인기 또는 비인기 메뉴 순위를 조회합니다.")
-    MenuAnalysisResponse getMenuAnalysis(
+    List<MenuAnalysisResponse> getMenuAnalysis(
             @Parameter(hidden = true)
             @AuthenticationPrincipal(expression = "id") Long storeId,
 
-            @Parameter(description = "분석 타입 (top: 인기, bottom: 비인기)", required = true, example = "top")
-            @RequestParam String type,
+            @Parameter(description = "분석 타입 (TOP: 인기, BOTTOM: 비인기)", required = true, example = "TOP")
+            @RequestParam MenuAnalysisType type,
 
-            @Parameter(description = "조회 기간 (daily: 오늘, weekly: 이번 주)", required = true, example = "daily")
-            @RequestParam String period,
+            @Parameter(description = "조회 기간 (DAILY: 오늘, WEEKLY: 이번 주)", required = true, example = "DAILY")
+            @RequestParam AnalysisPeriod period,
 
-            @Parameter(description = "조회할 메뉴 개수", example = "5")
+            @Parameter(description = "조회할 메뉴 개수")
             @RequestParam(defaultValue = "5") int limit
     );
 }

--- a/src/main/java/kr/elroy/aigoya/analytics/api/AnalyticsApi.java
+++ b/src/main/java/kr/elroy/aigoya/analytics/api/AnalyticsApi.java
@@ -8,8 +8,9 @@ import kr.elroy.aigoya.analytics.dto.request.MenuAnalysisType;
 import kr.elroy.aigoya.analytics.dto.response.DailySummaryResponse;
 import kr.elroy.aigoya.analytics.dto.response.HourlySalesResponse;
 import kr.elroy.aigoya.analytics.dto.response.MenuAnalysisResponse;
+import kr.elroy.aigoya.store.config.CurrentStoreId;
 import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -18,41 +19,52 @@ import java.time.LocalDate;
 import java.util.List;
 
 @Tag(name = "애널리틱스", description = "내 가게의 데이터 분석 API (인증 필요)")
+@Validated
 @RequestMapping("/v1/stores/me/analytics")
 public interface AnalyticsApi {
-    @GetMapping("/daily-summary")
     @Operation(summary = "일일 핵심 지표 요약", description = "특정 날짜의 총 매출, 거래 건수, 평균 객단가를 조회합니다.")
+    @GetMapping("/daily-summary")
     DailySummaryResponse getDailySummary(
+            @CurrentStoreId
             @Parameter(hidden = true)
-            @AuthenticationPrincipal(expression = "id") Long storeId,
+            Long storeId,
+
             @Parameter(description = "조회할 날짜 (YYYY-MM-DD). 미입력 시 오늘 날짜.")
             @RequestParam(required = false)
-            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate date
     );
 
-    @GetMapping("/sales-by-hour")
     @Operation(summary = "시간대별 매출 분석", description = "특정 날짜의 시간대별 매출 분포를 조회합니다.")
+    @GetMapping("/sales-by-hour")
     List<HourlySalesResponse> getSalesByHour(
+            @CurrentStoreId
             @Parameter(hidden = true)
-            @AuthenticationPrincipal(expression = "id") Long storeId,
+            Long storeId,
+
             @Parameter(description = "조회할 날짜 (YYYY-MM-DD). 미입력 시 오늘 날짜.")
             @RequestParam(required = false)
-            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate date
     );
 
-    @GetMapping("/menu-analysis")
     @Operation(summary = "메뉴 분석 (인기/비인기)", description = "기간별 인기 또는 비인기 메뉴 순위를 조회합니다.")
+    @GetMapping("/menu-analysis")
     List<MenuAnalysisResponse> getMenuAnalysis(
+            @CurrentStoreId
             @Parameter(hidden = true)
-            @AuthenticationPrincipal(expression = "id") Long storeId,
+            Long storeId,
 
             @Parameter(description = "분석 타입 (TOP: 인기, BOTTOM: 비인기)", required = true, example = "TOP")
-            @RequestParam MenuAnalysisType type,
+            @RequestParam
+            MenuAnalysisType type,
 
             @Parameter(description = "조회 기간 (DAILY: 오늘, WEEKLY: 이번 주)", required = true, example = "DAILY")
-            @RequestParam AnalysisPeriod period,
+            @RequestParam
+            AnalysisPeriod period,
 
             @Parameter(description = "조회할 메뉴 개수")
-            @RequestParam(defaultValue = "5") int limit
+            @RequestParam(defaultValue = "5")
+            Integer limit
     );
 }

--- a/src/main/java/kr/elroy/aigoya/analytics/controller/AnalyticsController.java
+++ b/src/main/java/kr/elroy/aigoya/analytics/controller/AnalyticsController.java
@@ -1,0 +1,35 @@
+package kr.elroy.aigoya.analytics.controller;
+
+import kr.elroy.aigoya.analytics.api.AnalyticsApi;
+import kr.elroy.aigoya.analytics.dto.request.AnalysisPeriod;
+import kr.elroy.aigoya.analytics.dto.request.MenuAnalysisType;
+import kr.elroy.aigoya.analytics.dto.response.DailySummaryResponse;
+import kr.elroy.aigoya.analytics.dto.response.HourlySalesResponse;
+import kr.elroy.aigoya.analytics.dto.response.MenuAnalysisResponse;
+import kr.elroy.aigoya.analytics.service.AnalyticsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class AnalyticsController implements AnalyticsApi {
+    private final AnalyticsService analyticsService;
+
+    @Override
+    public DailySummaryResponse getDailySummary(Long storeId, LocalDate date) {
+        return analyticsService.getDailySummary(storeId, date);
+    }
+
+    @Override
+    public List<HourlySalesResponse> getSalesByHour(Long storeId, LocalDate date) {
+        return analyticsService.getSalesByHour(storeId, date);
+    }
+
+    @Override
+    public List<MenuAnalysisResponse> getMenuAnalysis(Long storeId, MenuAnalysisType type, AnalysisPeriod period, Integer limit) {
+        return analyticsService.getMenuAnalysis(storeId, type, period, limit);
+    }
+}

--- a/src/main/java/kr/elroy/aigoya/analytics/dto/internal/DailySummaryRawDto.java
+++ b/src/main/java/kr/elroy/aigoya/analytics/dto/internal/DailySummaryRawDto.java
@@ -1,0 +1,15 @@
+package kr.elroy.aigoya.analytics.dto.internal;
+
+public record DailySummaryRawDto(
+        Long totalSales,
+        Long orderCount
+) {
+    public DailySummaryRawDto {
+        if (totalSales == null) {
+            totalSales = 0L;
+        }
+        if (orderCount == null) {
+            orderCount = 0L;
+        }
+    }
+}

--- a/src/main/java/kr/elroy/aigoya/analytics/dto/request/AnalysisPeriod.java
+++ b/src/main/java/kr/elroy/aigoya/analytics/dto/request/AnalysisPeriod.java
@@ -2,5 +2,5 @@ package kr.elroy.aigoya.analytics.dto.request;
 
 public enum AnalysisPeriod {
     DAILY,
-    WEEKLY;
+    WEEKLY
 }

--- a/src/main/java/kr/elroy/aigoya/analytics/dto/request/AnalysisPeriod.java
+++ b/src/main/java/kr/elroy/aigoya/analytics/dto/request/AnalysisPeriod.java
@@ -1,0 +1,6 @@
+package kr.elroy.aigoya.analytics.dto.request;
+
+public enum AnalysisPeriod {
+    DAILY,
+    WEEKLY;
+}

--- a/src/main/java/kr/elroy/aigoya/analytics/dto/request/MenuAnalysisType.java
+++ b/src/main/java/kr/elroy/aigoya/analytics/dto/request/MenuAnalysisType.java
@@ -1,0 +1,6 @@
+package kr.elroy.aigoya.analytics.dto.request;
+
+public enum MenuAnalysisType {
+    TOP,
+    BOTTOM;
+}

--- a/src/main/java/kr/elroy/aigoya/analytics/dto/request/MenuAnalysisType.java
+++ b/src/main/java/kr/elroy/aigoya/analytics/dto/request/MenuAnalysisType.java
@@ -2,5 +2,5 @@ package kr.elroy.aigoya.analytics.dto.request;
 
 public enum MenuAnalysisType {
     TOP,
-    BOTTOM;
+    BOTTOM
 }

--- a/src/main/java/kr/elroy/aigoya/analytics/dto/response/DailySummaryResponse.java
+++ b/src/main/java/kr/elroy/aigoya/analytics/dto/response/DailySummaryResponse.java
@@ -1,18 +1,17 @@
 package kr.elroy.aigoya.analytics.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDate;
+import lombok.Builder;
 
+@Builder
 public record DailySummaryResponse(
-        @Schema(description = "조회 날짜")
-        LocalDate date,
+        @Schema(description = "총 매출액", example = "100000")
+        Long totalSales,
 
-        @Schema(description = "총 매출액 (원)")
-        long totalSales,
+        @Schema(description = "총 주문 수", example = "10")
+        Long orderCount,
 
-        @Schema(description = "거래 건수")
-        int transactionCount,
-
-        @Schema(description = "평균 객단가 (원)")
-        long averageTransactionValue
-) {}
+        @Schema(description = "객단가", example = "10000")
+        Long averageOrderValue
+) {
+}

--- a/src/main/java/kr/elroy/aigoya/analytics/dto/response/DailySummaryResponse.java
+++ b/src/main/java/kr/elroy/aigoya/analytics/dto/response/DailySummaryResponse.java
@@ -1,0 +1,18 @@
+package kr.elroy.aigoya.analytics.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+
+public record DailySummaryResponse(
+        @Schema(description = "조회 날짜")
+        LocalDate date,
+
+        @Schema(description = "총 매출액 (원)")
+        long totalSales,
+
+        @Schema(description = "거래 건수")
+        int transactionCount,
+
+        @Schema(description = "평균 객단가 (원)")
+        long averageTransactionValue
+) {}

--- a/src/main/java/kr/elroy/aigoya/analytics/dto/response/HourlySalesResponse.java
+++ b/src/main/java/kr/elroy/aigoya/analytics/dto/response/HourlySalesResponse.java
@@ -1,11 +1,14 @@
 package kr.elroy.aigoya.analytics.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 
+@Builder
 public record HourlySalesResponse(
-        @Schema(description = "시간 (0~23)")
-        int hour,
+        @Schema(description = "시간", example = "10")
+        Integer hour,
 
-        @Schema(description = "해당 시간대 매출액")
-        long sales
-) {}
+        @Schema(description = "매출액", example = "100000")
+        Long totalSales
+) {
+}

--- a/src/main/java/kr/elroy/aigoya/analytics/dto/response/HourlySalesResponse.java
+++ b/src/main/java/kr/elroy/aigoya/analytics/dto/response/HourlySalesResponse.java
@@ -1,0 +1,11 @@
+package kr.elroy.aigoya.analytics.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record HourlySalesResponse(
+        @Schema(description = "시간 (0~23)")
+        int hour,
+
+        @Schema(description = "해당 시간대 매출액")
+        long sales
+) {}

--- a/src/main/java/kr/elroy/aigoya/analytics/dto/response/MenuAnalysisResponse.java
+++ b/src/main/java/kr/elroy/aigoya/analytics/dto/response/MenuAnalysisResponse.java
@@ -1,17 +1,17 @@
 package kr.elroy.aigoya.analytics.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 
+@Builder
 public record MenuAnalysisResponse(
-        @Schema(description = "상품 ID")
-        Long productId,
+        @Schema(description = "메뉴 이름", example = "피자")
+        String menuName,
 
-        @Schema(description = "상품명")
-        String productName,
+        @Schema(description = "판매 수", example = "10")
+        Long salesCount,
 
-        @Schema(description = "총 판매 수량")
-        long totalQuantity,
-
-        @Schema(description = "총 판매 금액")
-        long totalSales
-) {}
+        @Schema(description = "매출액", example = "100000")
+        Long totalSales
+) {
+}

--- a/src/main/java/kr/elroy/aigoya/analytics/dto/response/MenuAnalysisResponse.java
+++ b/src/main/java/kr/elroy/aigoya/analytics/dto/response/MenuAnalysisResponse.java
@@ -1,0 +1,17 @@
+package kr.elroy.aigoya.analytics.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MenuAnalysisResponse(
+        @Schema(description = "상품 ID")
+        Long productId,
+
+        @Schema(description = "상품명")
+        String productName,
+
+        @Schema(description = "총 판매 수량")
+        long totalQuantity,
+
+        @Schema(description = "총 판매 금액")
+        long totalSales
+) {}

--- a/src/main/java/kr/elroy/aigoya/analytics/exception/InvalidAnalysisParameterException.java
+++ b/src/main/java/kr/elroy/aigoya/analytics/exception/InvalidAnalysisParameterException.java
@@ -1,0 +1,10 @@
+package kr.elroy.aigoya.analytics.exception;
+
+import kr.elroy.aigoya.exception.DomainException;
+import kr.elroy.aigoya.exception.ErrorCode;
+
+public class InvalidAnalysisParameterException extends DomainException {
+    public InvalidAnalysisParameterException() {
+        super(ErrorCode.INVALID_ANALYSIS_PARAMETER);
+    }
+}

--- a/src/main/java/kr/elroy/aigoya/analytics/repository/AnalyticsRepository.java
+++ b/src/main/java/kr/elroy/aigoya/analytics/repository/AnalyticsRepository.java
@@ -1,0 +1,61 @@
+package kr.elroy.aigoya.analytics.repository;
+
+import kr.elroy.aigoya.analytics.dto.internal.DailySummaryRawDto;
+import kr.elroy.aigoya.analytics.dto.response.HourlySalesResponse;
+import kr.elroy.aigoya.analytics.dto.response.MenuAnalysisResponse;
+import kr.elroy.aigoya.order.domain.Order;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface AnalyticsRepository extends JpaRepository<Order, Long> {
+
+    @Query("SELECT new kr.elroy.aigoya.analytics.dto.internal.DailySummaryRawDto(SUM(o.totalPrice), COUNT(o.id)) " +
+           "FROM orders o " +
+           "WHERE o.store.id = :storeId AND o.orderedAt >= :startOfDay AND o.orderedAt < :endOfDay")
+    DailySummaryRawDto findDailySummaryRaw(
+            @Param("storeId") Long storeId,
+            @Param("startOfDay") LocalDateTime startOfDay,
+            @Param("endOfDay") LocalDateTime endOfDay
+    );
+
+    @Query("SELECT new kr.elroy.aigoya.analytics.dto.response.HourlySalesResponse(hour(o.orderedAt), SUM(o.totalPrice)) " +
+           "FROM orders o " +
+           "WHERE o.store.id = :storeId AND o.orderedAt >= :startOfDay AND o.orderedAt < :endOfDay " +
+           "GROUP BY hour(o.orderedAt) " +
+           "ORDER BY hour(o.orderedAt) ASC")
+    List<HourlySalesResponse> findHourlySales(
+            @Param("storeId") Long storeId,
+            @Param("startOfDay") LocalDateTime startOfDay,
+            @Param("endOfDay") LocalDateTime endOfDay
+    );
+
+    @Query(value = "SELECT new kr.elroy.aigoya.analytics.dto.response.MenuAnalysisResponse(p.name, SUM(op.quantity), SUM(op.quantity * p.price)) " +
+            "FROM order_product op JOIN op.product p JOIN op.order o " +
+            "WHERE o.store.id = :storeId AND o.orderedAt >= :startDate AND o.orderedAt < :endDate " +
+            "GROUP BY p.id, p.name " +
+            "ORDER BY SUM(op.quantity) DESC, SUM(op.quantity * p.price) DESC")
+    Page<MenuAnalysisResponse> findMenuAnalysisTop(
+            @Param("storeId") Long storeId,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate,
+            Pageable pageable
+    );
+
+    @Query(value = "SELECT new kr.elroy.aigoya.analytics.dto.response.MenuAnalysisResponse(p.name, SUM(op.quantity), SUM(op.quantity * p.price)) " +
+            "FROM order_product op JOIN op.product p JOIN op.order o " +
+            "WHERE o.store.id = :storeId AND o.orderedAt >= :startDate AND o.orderedAt < :endDate " +
+            "GROUP BY p.id, p.name " +
+            "ORDER BY SUM(op.quantity) ASC, SUM(op.quantity * p.price) ASC")
+    Page<MenuAnalysisResponse> findMenuAnalysisBottom(
+            @Param("storeId") Long storeId,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate,
+            Pageable pageable
+    );
+}

--- a/src/main/java/kr/elroy/aigoya/analytics/service/AnalyticsService.java
+++ b/src/main/java/kr/elroy/aigoya/analytics/service/AnalyticsService.java
@@ -1,0 +1,94 @@
+package kr.elroy.aigoya.analytics.service;
+
+import kr.elroy.aigoya.analytics.dto.internal.DailySummaryRawDto;
+import kr.elroy.aigoya.analytics.dto.request.AnalysisPeriod;
+import kr.elroy.aigoya.analytics.dto.request.MenuAnalysisType;
+import kr.elroy.aigoya.analytics.dto.response.DailySummaryResponse;
+import kr.elroy.aigoya.analytics.dto.response.HourlySalesResponse;
+import kr.elroy.aigoya.analytics.dto.response.MenuAnalysisResponse;
+import kr.elroy.aigoya.analytics.exception.InvalidAnalysisParameterException;
+import kr.elroy.aigoya.analytics.repository.AnalyticsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.WeekFields;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AnalyticsService {
+
+    private static final int MAX_MENU_ANALYSIS_LIMIT = 50;
+
+    private final AnalyticsRepository analyticsRepository;
+
+    public DailySummaryResponse getDailySummary(Long storeId, LocalDate date) {
+        LocalDate targetDate = (date == null) ? LocalDate.now() : date;
+        LocalDateTime startOfDay = targetDate.atStartOfDay();
+        LocalDateTime endOfDay = targetDate.atTime(LocalTime.MAX);
+
+        DailySummaryRawDto rawDto = analyticsRepository.findDailySummaryRaw(storeId, startOfDay, endOfDay);
+
+        Long totalSales = rawDto.totalSales();
+        Long orderCount = rawDto.orderCount();
+        long averageOrderValue = (orderCount == 0) ? 0 : totalSales / orderCount;
+
+        return DailySummaryResponse.builder()
+                .totalSales(totalSales)
+                .orderCount(orderCount)
+                .averageOrderValue(averageOrderValue)
+                .build();
+    }
+
+    public List<HourlySalesResponse> getSalesByHour(Long storeId, LocalDate date) {
+        LocalDate targetDate = (date == null) ? LocalDate.now() : date;
+        LocalDateTime startOfDay = targetDate.atStartOfDay();
+        LocalDateTime endOfDay = targetDate.atTime(LocalTime.MAX);
+
+        List<HourlySalesResponse> salesByHour = analyticsRepository.findHourlySales(storeId, startOfDay, endOfDay);
+        Map<Integer, Long> salesMap = salesByHour.stream()
+                .collect(Collectors.toMap(HourlySalesResponse::hour, HourlySalesResponse::totalSales));
+
+        return IntStream.range(0, 24)
+                .mapToObj(hour -> HourlySalesResponse.builder()
+                        .hour(hour)
+                        .totalSales(salesMap.getOrDefault(hour, 0L))
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    public List<MenuAnalysisResponse> getMenuAnalysis(Long storeId, MenuAnalysisType type, AnalysisPeriod period, Integer limit) {
+        if (limit <= 0 || limit > MAX_MENU_ANALYSIS_LIMIT) {
+            throw new InvalidAnalysisParameterException();
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime startDate;
+
+        if (period == AnalysisPeriod.DAILY) {
+            startDate = now.toLocalDate().atStartOfDay();
+        } else {
+            WeekFields weekFields = WeekFields.of(Locale.getDefault());
+            startDate = now.with(weekFields.dayOfWeek(), 1).toLocalDate().atStartOfDay();
+        }
+
+        Pageable pageable = PageRequest.of(0, limit);
+
+        if (type == MenuAnalysisType.TOP) {
+            return analyticsRepository.findMenuAnalysisTop(storeId, startDate, now, pageable).getContent();
+        } else {
+            return analyticsRepository.findMenuAnalysisBottom(storeId, startDate, now, pageable).getContent();
+        }
+    }
+}

--- a/src/main/java/kr/elroy/aigoya/exception/ErrorCode.java
+++ b/src/main/java/kr/elroy/aigoya/exception/ErrorCode.java
@@ -8,6 +8,9 @@ import lombok.RequiredArgsConstructor;
 public enum ErrorCode {
     ACCESS_DENIED(403, "AUTH_0001", "접근 권한이 없습니다."),
 
+    // Analytics
+    INVALID_ANALYSIS_PARAMETER(400, "ANALYTICS_0001", "유효하지 않은 분석 파라미터입니다."),
+
     ORDER_NOT_FOUND(404, "ORDER_0001", "주문을 찾을 수 없습니다."),
 
     PRODUCT_NOT_FOUND(404, "PRODUCT_0001", "상품을 찾을 수 없습니다."),


### PR DESCRIPTION
# 이 PR이 하는 일
가게의 데이터를 분석하고 시각화하기 위한 애널리틱스 모듈의 기본 API 명세와 응답 DTO를 설계했습니다.

## 설명
- **일일 핵심 지표 요약 API** (`/daily-summary`)
  - 총 매출, 거래 건수, 평균 객단가 조회

- **시간대별 매출 분석 API** (`/sales-by-hour`)
  - 특정 날짜의 시간대별 매출 분포 조회

- **메뉴 분석 API** (`/menu-analysis`)
  - 기간별 인기/비인기 메뉴 순위 조회

## 아키텍처
- `AnalyticsApi` 인터페이스를 생성하여 API의 명세(contract)를 정의하고, 컨트롤러 구현체와 역할을 분리했습니다.

- 각 API 엔드포인트가 반환할 데이터 구조에 맞춰 `DailySummaryResponse`, `HourlySalesResponse`, `MenuAnalysisResponse` DTO를 정의했습니다.

- DTO는 프론트엔드에서 바로 시각화에 사용할 수 있도록 가공된 데이터를 제공하는 것을 목표로 설계되었습니다.
