### PR TITLE
refactor: 회원가입 단계 간소화 및 마이페이지 내에 선택적 수정 허용

### DIFF
--- a/src/main/java/kr/elroy/aigoya/store/domain/Store.java
+++ b/src/main/java/kr/elroy/aigoya/store/domain/Store.java
@@ -43,9 +43,9 @@ public class Store {
     @Column(name = "phone", nullable = false)
     private String phone;
 
-    @Column(name = "address", nullable = false)
+    @Column(name = "address")
     private String address;
 
-    @Column(name = "dailyTarget", nullable = false)
-    private String dailyTarget;
+    @Column(name = "dailyTarget")
+    private Long dailyTarget;
 }

--- a/src/main/java/kr/elroy/aigoya/store/dto/request/CreateStoreRequest.java
+++ b/src/main/java/kr/elroy/aigoya/store/dto/request/CreateStoreRequest.java
@@ -22,12 +22,10 @@ public record CreateStoreRequest(
         @Schema(description = "전화번호", example = "010-1234-5678")
         String phone,
 
-        @NotBlank(message = "주소는 필수입니다.")
-        @Schema(description = "가게 주소", example = "서울시 강남구 테헤란로 123")
+        @Schema(description = "가게 주소 (선택)", example = "서울시 강남구 테헤란로 123")
         String address,
 
-        @NotBlank(message = "일일 목표 매출은 필수입니다.")
-        @Schema(description = "일일 목표 매출", example = "1000000")
-        String dailyTarget
+        @Schema(description = "일일 목표 매출 (선택)", example = "1000000")
+        Long dailyTarget
 ) {
 }

--- a/src/main/java/kr/elroy/aigoya/store/dto/request/UpdateStoreRequest.java
+++ b/src/main/java/kr/elroy/aigoya/store/dto/request/UpdateStoreRequest.java
@@ -1,23 +1,19 @@
 package kr.elroy.aigoya.store.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 
-@Schema(description = "가게 정보 수정 요청")
+@Schema(description = "가게 정보 수정 요청 (변경하려는 필드만 포함)")
 public record UpdateStoreRequest(
-        @NotBlank(message = "가게 이름은 필수입니다.")
         @Schema(description = "새로운 가게 이름", example = "The New Elroy Store")
         String name,
 
-        @NotBlank(message = "전화번호는 필수입니다.")
         @Schema(description = "새로운 전화번호", example = "010-9876-5432")
         String phone,
 
-        @NotBlank(message = "주소는 필수입니다.")
         @Schema(description = "새로운 가게 주소", example = "부산시 해운대구 우동 1234")
         String address,
 
-        @NotBlank(message = "일일 목표 매출은 필수입니다.")
         @Schema(description = "새로운 일일 목표 매출", example = "1200000")
-        String dailyTarget
-) {}
+        Long dailyTarget
+) {
+}

--- a/src/main/java/kr/elroy/aigoya/store/dto/response/StoreResponse.java
+++ b/src/main/java/kr/elroy/aigoya/store/dto/response/StoreResponse.java
@@ -21,7 +21,7 @@ public record StoreResponse(
         String address,
 
         @Schema(description = "일일 목표 매출", example = "1000000")
-        String dailyTarget
+        Long dailyTarget
 ) {
 
     public static StoreResponse of(Store store) {

--- a/src/main/java/kr/elroy/aigoya/store/service/StoreService.java
+++ b/src/main/java/kr/elroy/aigoya/store/service/StoreService.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -67,10 +68,18 @@ public class StoreService {
     public Store updateStore(Long storeId, UpdateStoreRequest request) {
         Store store = getStore(storeId);
 
-        store.setName(request.name());
-        store.setPhone(request.phone());
-        store.setAddress(request.address());
-        store.setDailyTarget(request.dailyTarget());
+        if (request.name() != null) {
+            store.setName(request.name());
+        }
+        if (request.phone() != null) {
+            store.setPhone(request.phone());
+        }
+        if (request.address() != null) {
+            store.setAddress(request.address());
+        }
+        if (request.dailyTarget() != null) {
+            store.setDailyTarget(request.dailyTarget());
+        }
 
         return store;
     }


### PR DESCRIPTION
## 이 PR이 하는 일
사용자 가입 및 설정 관련 리팩토링

## 설명

1. 회원가입 절차 간소화

- 필수로 받는 address와 dailyTarget을 선택 사항으로 변경

2. 마이페이지 정보 수정 기능 강화

- 기존에 업데이트를 하려면 @NotBlank가 되어있어 모든 필드의 수정이 불가피했지만 제거 후 변경이 필요한 필드만 수정하게 함
- 이로 인해 null일때는 null값으로 수정되는 문제가 있어 null이 아닐 경우에만 수정이 되도록 변경했음

3. dailyTarget의 필드 타입 변경(String -> Long)

- 데이터의 정확성과 수학적 연산을 용이하게 하기위해 타입을 변경
- store엔티티 및 DTO들이 일관성있게 수정해두었음