### PR TITLE
feat: 대화형 AI 에이전트 아키텍쳐 도입 및 데이터 기반 분석과 날씨 연동 분석등 개발 완료

### DIFF
--- a/src/main/java/kr/elroy/aigoya/ai/controller/AiController.java
+++ b/src/main/java/kr/elroy/aigoya/ai/controller/AiController.java
@@ -1,11 +1,10 @@
 package kr.elroy.aigoya.ai.controller;
 
-import kr.elroy.aigoya.ai.dto.request.AiChatRequest;
+import kr.elroy.aigoya.ai.dto.request.ChatRequest;
 import kr.elroy.aigoya.ai.dto.response.ReportResponse;
-import kr.elroy.aigoya.ai.service.AiService;
-import kr.elroy.aigoya.security.CustomUserDetails;
+import kr.elroy.aigoya.ai.service.AgentService;
+import kr.elroy.aigoya.store.config.CurrentStoreId;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,26 +15,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AiController {
 
-    private final AiService aiService;
+    private final AgentService agentService;
 
     @PostMapping("/chat")
     public ReportResponse chat(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestBody AiChatRequest request
+            @CurrentStoreId Long storeId,
+            @RequestBody ChatRequest request
     ) {
-        Long storeId = userDetails.getStore().getId();
         String message = request.message();
-        String result;
 
-        if (message.contains("매출") || message.contains("보고서")) {
-            result = aiService.generateSalesReport(storeId);
-        } else if (message.contains("재고") || message.contains("예측")) {
-            result = aiService.predictInventory(storeId);
-        } else if (message.contains("마케팅") || message.contains("문구") || message.contains("메시지")) {
-            result = aiService.generateMarketingCopy(storeId, message);
-        } else {
-            result = "죄송합니다, 요청을 이해하지 못했습니다. '매출 보고서', '재고 예측', '마케팅 문구' 등으로 말씀해주세요.";
-        }
+        String result = agentService.chat(storeId, message);
 
         return new ReportResponse(result);
     }

--- a/src/main/java/kr/elroy/aigoya/ai/domain/ChatMessage.java
+++ b/src/main/java/kr/elroy/aigoya/ai/domain/ChatMessage.java
@@ -1,0 +1,48 @@
+package kr.elroy.aigoya.ai.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import kr.elroy.aigoya.store.domain.Store;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class ChatMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ChatRole role;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/kr/elroy/aigoya/ai/domain/ChatMessageRepository.java
+++ b/src/main/java/kr/elroy/aigoya/ai/domain/ChatMessageRepository.java
@@ -1,0 +1,11 @@
+package kr.elroy.aigoya.ai.domain;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+    List<ChatMessage> findByStoreIdOrderByCreatedAtDesc(Long storeId, Pageable pageable);
+}

--- a/src/main/java/kr/elroy/aigoya/ai/domain/ChatRole.java
+++ b/src/main/java/kr/elroy/aigoya/ai/domain/ChatRole.java
@@ -1,0 +1,6 @@
+package kr.elroy.aigoya.ai.domain;
+
+public enum ChatRole {
+    USER,
+    AI
+}

--- a/src/main/java/kr/elroy/aigoya/ai/dto/request/ChatRequest.java
+++ b/src/main/java/kr/elroy/aigoya/ai/dto/request/ChatRequest.java
@@ -2,4 +2,4 @@ package kr.elroy.aigoya.ai.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record AiChatRequest(@NotBlank String message) {}
+public record ChatRequest(@NotBlank String message) {}

--- a/src/main/java/kr/elroy/aigoya/ai/service/AgentService.java
+++ b/src/main/java/kr/elroy/aigoya/ai/service/AgentService.java
@@ -1,0 +1,148 @@
+package kr.elroy.aigoya.ai.service;
+
+import kr.elroy.aigoya.ai.domain.ChatMessage;
+import kr.elroy.aigoya.ai.domain.ChatMessageRepository;
+import kr.elroy.aigoya.ai.domain.ChatRole;
+import kr.elroy.aigoya.store.domain.Store;
+import kr.elroy.aigoya.store.repository.StoreRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.prompt.PromptTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@Transactional
+public class AgentService {
+
+    private static final int HISTORY_SIZE = 5;
+
+    private final AiService aiService;
+    private final StoreRepository storeRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatClient chatClient;
+    private final PromptTemplate routerPromptTemplate;
+    private final PromptTemplate finalSynthesisPromptTemplate;
+    private final PromptTemplate summaryPromptTemplate;
+
+    public AgentService(AiService aiService, StoreRepository storeRepository, ChatMessageRepository chatMessageRepository, ChatClient.Builder chatClientBuilder,
+                        @Value("classpath:/prompts/ai-router-prompt.st") Resource routerResource,
+                        @Value("classpath:/prompts/final-synthesis-prompt.st") Resource finalSynthesisResource,
+                        @Value("classpath:/prompts/history-summary-prompt.st") Resource summaryResource) {
+        this.aiService = aiService;
+        this.storeRepository = storeRepository;
+        this.chatMessageRepository = chatMessageRepository;
+        this.chatClient = chatClientBuilder.build();
+        this.routerPromptTemplate = new PromptTemplate(routerResource);
+        this.finalSynthesisPromptTemplate = new PromptTemplate(finalSynthesisResource);
+        this.summaryPromptTemplate = new PromptTemplate(summaryResource);
+    }
+
+    public String chat(Long storeId, String userMessage) {
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid store Id:" + storeId));
+
+        saveMessage(store, ChatRole.USER, userMessage);
+
+        String fullChatHistory = getFormattedChatHistory(storeId);
+
+        String historySummary = summarizeChatHistory(fullChatHistory);
+        log.info("Chat history summarized: {}", historySummary);
+
+        String routerInput = historySummary + "\nUSER: " + userMessage;
+        String[] toolNames = getRouteFromAi(routerInput).split(",");
+        log.info("AI Router selected tool(s): {}", (Object) toolNames);
+
+        String finalResponse;
+
+        if (toolNames.length > 0 && !toolNames[0].equals("CHAT")) {
+            Map<String, String> toolResults = new HashMap<>();
+            for (String toolName : toolNames) {
+                String result = executeTool(toolName.trim(), storeId, userMessage, historySummary);
+                toolResults.put(toolName.trim(), result);
+            }
+
+            finalResponse = synthesizeFinalResponse(historySummary, toolResults);
+
+        } else {
+            finalResponse = "죄송합니다, 요청을 이해하지 못했습니다. '매출 보고서', '재고 예측', '마케팅 문구' 등으로 말씀해주세요.";
+        }
+
+        saveMessage(store, ChatRole.AI, finalResponse);
+        return finalResponse;
+    }
+
+    private String executeTool(String toolName, Long storeId, String userMessage, String chatHistorySummary) {
+        switch (toolName) {
+            case "generateSalesReport":
+                return aiService.generateSalesReport(storeId, chatHistorySummary);
+            case "predictInventory":
+                return aiService.predictInventory(storeId, chatHistorySummary);
+            case "generateMarketingCopy":
+                return aiService.generateMarketingCopy(storeId, userMessage, chatHistorySummary);
+            case "analyzeSalesByWeather":
+                return aiService.analyzeSalesByWeather(storeId, chatHistorySummary);
+            case "getWeather":
+                return aiService.getCurrentWeather(storeId);
+            default:
+                return "알 수 없는 도구입니다: " + toolName;
+        }
+    }
+
+    private String synthesizeFinalResponse(String chatHistorySummary, Map<String, String> toolResults) {
+        String formattedResults = toolResults.entrySet().stream()
+                .map(entry -> "--- " + entry.getKey() + " 결과 ---\n" + entry.getValue())
+                .collect(Collectors.joining("\n\n"));
+
+        return chatClient.prompt(finalSynthesisPromptTemplate.create(Map.of(
+                        "chatHistory", chatHistorySummary,
+                        "toolResults", formattedResults
+                )))
+                .call()
+                .content();
+    }
+
+    private String getRouteFromAi(String routerInput) {
+        return chatClient.prompt(routerPromptTemplate.create(Map.of("chatHistory", routerInput)))
+                .call()
+                .content();
+    }
+
+    private String summarizeChatHistory(String fullChatHistory) {
+        if (fullChatHistory.isBlank()) {
+            return "No previous conversation.";
+        }
+        return chatClient.prompt(summaryPromptTemplate.create(Map.of("chatHistory", fullChatHistory)))
+                .call()
+                .content();
+    }
+
+    private String getFormattedChatHistory(Long storeId) {
+        Pageable pageable = PageRequest.of(0, HISTORY_SIZE);
+        List<ChatMessage> recentMessages = chatMessageRepository.findByStoreIdOrderByCreatedAtDesc(storeId, pageable);
+        Collections.reverse(recentMessages);
+        return recentMessages.stream()
+                .map(message -> message.getRole().name() + ": " + message.getContent())
+                .collect(Collectors.joining("\n"));
+    }
+
+    private void saveMessage(Store store, ChatRole role, String content) {
+        ChatMessage message = ChatMessage.builder()
+                .store(store)
+                .role(role)
+                .content(content)
+                .build();
+        chatMessageRepository.save(message);
+    }
+}

--- a/src/main/java/kr/elroy/aigoya/ai/service/AiService.java
+++ b/src/main/java/kr/elroy/aigoya/ai/service/AiService.java
@@ -2,14 +2,15 @@ package kr.elroy.aigoya.ai.service;
 
 import kr.elroy.aigoya.order.OrderRepository;
 import kr.elroy.aigoya.order.domain.Order;
-import kr.elroy.aigoya.order.domain.OrderProduct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.prompt.PromptTemplate;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -21,37 +22,69 @@ public class AiService {
     private final ChatClient chatClient;
     private final PromptTemplate salesReportTemplate;
     private final PromptTemplate inventoryPredictionTemplate;
-    private final PromptTemplate marketingCopyTemplate; // 1. 필드 추가
+    private final PromptTemplate marketingCopyTemplate;
+    private final PromptTemplate salesAnalysisByWeatherTemplate;
     private final OrderRepository orderRepository;
+    private final WeatherService weatherService;
 
     public AiService(ChatClient.Builder chatClientBuilder,
                      @Value("classpath:/prompts/sales-report.st") Resource salesReportResource,
                      @Value("classpath:/prompts/inventory-prediction.st") Resource inventoryPredictionResource,
-                     @Value("classpath:/prompts/marketing-copy.st") Resource marketingCopyResource, // 2. 프롬프트 로드
-                     OrderRepository orderRepository) {
+                     @Value("classpath:/prompts/marketing-copy.st") Resource marketingCopyResource,
+                     @Value("classpath:/prompts/sales-analysis-by-weather-prompt.st") Resource salesAnalysisByWeatherResource,
+                     OrderRepository orderRepository,
+                     WeatherService weatherService) {
         this.chatClient = chatClientBuilder.build();
         this.salesReportTemplate = new PromptTemplate(salesReportResource);
         this.inventoryPredictionTemplate = new PromptTemplate(inventoryPredictionResource);
-        this.marketingCopyTemplate = new PromptTemplate(marketingCopyResource); // 2. 프롬프트 초기화
+        this.marketingCopyTemplate = new PromptTemplate(marketingCopyResource);
+        this.salesAnalysisByWeatherTemplate = new PromptTemplate(salesAnalysisByWeatherResource);
         this.orderRepository = orderRepository;
+        this.weatherService = weatherService;
     }
 
-    public String generateSalesReport(Long storeId) {
-        List<Order> orders = orderRepository.findAllByStoreId(storeId);
-        String salesData = convertOrdersToSalesDataString(orders);
-        return callAiModel(salesReportTemplate, Map.of("salesData", salesData), "보고서 생성");
+    @Transactional(readOnly = true)
+    public String getCurrentWeather(Long storeId) {
+        return weatherService.getWeatherForStore(storeId, LocalDate.now());
     }
 
-    public String predictInventory(Long storeId) {
+    @Transactional(readOnly = true)
+    public String generateSalesReport(Long storeId, String chatHistory) {
         List<Order> orders = orderRepository.findAllByStoreId(storeId);
         String salesData = convertOrdersToSalesDataString(orders);
-        return callAiModel(inventoryPredictionTemplate, Map.of("salesData", salesData), "재고 예측");
+        return callAiModel(salesReportTemplate, Map.of("salesData", salesData, "chatHistory", chatHistory), "보고서 생성");
     }
 
-    public String generateMarketingCopy(Long storeId, String userRequest) {
+    @Transactional(readOnly = true)
+    public String predictInventory(Long storeId, String chatHistory) {
         List<Order> orders = orderRepository.findAllByStoreId(storeId);
         String salesData = convertOrdersToSalesDataString(orders);
-        return callAiModel(marketingCopyTemplate, Map.of("salesData", salesData, "request", userRequest), "마케팅 문구 생성");
+        return callAiModel(inventoryPredictionTemplate, Map.of("salesData", salesData, "chatHistory", chatHistory), "재고 예측");
+    }
+
+    @Transactional(readOnly = true)
+    public String generateMarketingCopy(Long storeId, String userRequest, String chatHistory) {
+        List<Order> orders = orderRepository.findAllByStoreId(storeId);
+        String salesData = convertOrdersToSalesDataString(orders);
+        return callAiModel(marketingCopyTemplate, Map.of("salesData", salesData, "request", userRequest, "chatHistory", chatHistory), "마케팅 문구 생성");
+    }
+
+    @Transactional(readOnly = true)
+    public String analyzeSalesByWeather(Long storeId, String chatHistory) {
+        List<Order> orders = orderRepository.findAllByStoreId(storeId);
+
+        String salesAndWeatherData = orders.stream()
+                .flatMap(order -> {
+                    String weather = weatherService.getWeatherForStore(storeId, order.getOrderedAt().toLocalDate());
+                    return order.getOrderProducts().stream()
+                            .map(op -> String.format("날짜: %s, 날씨: %s, 상품: %s, 수량: %d",
+                                    order.getOrderedAt().toLocalDate(), weather, op.getProduct().getName(), op.getQuantity()));
+                })
+                .collect(Collectors.joining("\n"));
+
+        log.info("Sales and Weather Data for AI Analysis:\n{}", salesAndWeatherData);
+
+        return callAiModel(salesAnalysisByWeatherTemplate, Map.of("salesAndWeatherData", salesAndWeatherData, "chatHistory", chatHistory), "날씨 기반 분석");
     }
 
     private String callAiModel(PromptTemplate promptTemplate, Map<String, Object> params, String taskName) {
@@ -74,7 +107,7 @@ public class AiService {
                 .map(order -> {
                     String productsInfo = order.getOrderProducts().stream()
                             .map(op -> String.format("  - Product: %s, Quantity: %d, Price: %d",
-                                    op.getProduct().getName(), op.getQuantity(), op.getOrderPrice()))
+                                    op.getProduct().getName(), op.getQuantity(), op.getProduct().getPrice()))
                             .collect(Collectors.joining("\n"));
                     return String.format("Order ID: %d, Store ID: %d, Ordered At: %s, Total Price: %d\n%s",
                             order.getId(), order.getStore().getId(), order.getOrderedAt(), order.getTotalPrice(), productsInfo);

--- a/src/main/java/kr/elroy/aigoya/ai/service/WeatherService.java
+++ b/src/main/java/kr/elroy/aigoya/ai/service/WeatherService.java
@@ -1,0 +1,123 @@
+package kr.elroy.aigoya.ai.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import kr.elroy.aigoya.store.domain.Store;
+import kr.elroy.aigoya.store.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.StreamSupport;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WeatherService {
+
+    private final WebClient.Builder webClientBuilder;
+    private final StoreRepository storeRepository;
+
+    @Value("${kma.api.service-key}")
+    private String serviceKey;
+
+    @Value("${kma.api.url}")
+    private String apiUrl;
+
+    private static final int DEFAULT_NX = 60;
+    private static final int DEFAULT_NY = 127;
+
+    public String getWeatherFor(LocalDate date, int nx, int ny) {
+        String baseDate = date.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String baseTime = "0500";
+
+        try {
+            WebClient webClient = webClientBuilder.build();
+            Mono<JsonNode> responseMono = webClient.get()
+                    .uri(apiUrl, uriBuilder -> uriBuilder
+                            .queryParam("serviceKey", serviceKey)
+                            .queryParam("pageNo", 1)
+                            .queryParam("numOfRows", 1000)
+                            .queryParam("dataType", "JSON")
+                            .queryParam("base_date", baseDate)
+                            .queryParam("base_time", baseTime)
+                            .queryParam("nx", nx)
+                            .queryParam("ny", ny)
+                            .build())
+                    .retrieve()
+                    .bodyToMono(JsonNode.class);
+
+            JsonNode response = responseMono.block();
+            return parseWeatherFromResponse(response, baseDate);
+        } catch (Exception e) {
+            log.error("Failed to fetch weather data for nx={}, ny={}", nx, ny, e);
+            return "날씨 정보 없음";
+        }
+    }
+
+    private String parseWeatherFromResponse(JsonNode response, String targetDate) {
+        JsonNode items = response.path("response").path("body").path("items").path("item");
+        if (!items.isArray()) {
+            log.warn("KMA API response format is not as expected or contains an error: {}", response.path("response").path("header").path("resultMsg").asText());
+            return "날씨 정보 없음";
+        }
+
+        String precipitation = StreamSupport.stream(items.spliterator(), false)
+                .filter(item -> Objects.equals(item.path("fcstDate").asText(), targetDate))
+                .filter(item -> "PTY".equals(item.path("category").asText()))
+                .map(item -> item.path("fcstValue").asInt())
+                .filter(ptyCode -> ptyCode > 0)
+                .findFirst()
+                .map(this::translatePtyCode)
+                .orElse(null);
+
+        if (precipitation != null) {
+            return precipitation;
+        }
+
+        return StreamSupport.stream(items.spliterator(), false)
+                .filter(item -> Objects.equals(item.path("fcstDate").asText(), targetDate))
+                .filter(item -> "SKY".equals(item.path("category").asText()))
+                .filter(item -> "1200".equals(item.path("fcstTime").asText()))
+                .findFirst()
+                .map(item -> item.path("fcstValue").asInt())
+                .map(this::translateSkyCode)
+                .orElse("맑음");
+    }
+
+    private String translatePtyCode(int code) {
+        return switch (code) {
+            case 1 -> "비";
+            case 2 -> "비/눈";
+            case 3 -> "눈";
+            case 4 -> "소나기";
+            default -> null;
+        };
+    }
+
+    private String translateSkyCode(int code) {
+        return switch (code) {
+            case 1 -> "맑음";
+            case 3 -> "구름많음";
+            case 4 -> "흐림";
+            default -> null;
+        };
+    }
+
+    public String getWeatherForStore(Long storeId, LocalDate date) {
+        Optional<Store> storeOptional = storeRepository.findById(storeId);
+
+        int nx = storeOptional.map(Store::getNx).orElse(DEFAULT_NX);
+        int ny = storeOptional.map(Store::getNy).orElse(DEFAULT_NY);
+
+        log.info("Fetching weather for storeId: {} (nx={}, ny={})", storeId, nx, ny);
+
+        return getWeatherFor(date, nx, ny);
+    }
+}

--- a/src/main/java/kr/elroy/aigoya/security/SecurityConfig.java
+++ b/src/main/java/kr/elroy/aigoya/security/SecurityConfig.java
@@ -26,6 +26,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
                                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                                 .requestMatchers("/v1/stores/login", "/v1/stores/create").permitAll()
+                                .requestMatchers("/api/ai/**").permitAll()
                                 .requestMatchers("/v1/stores/admin/**").hasRole("ADMIN")
                                 .anyRequest().authenticated()
 //                  .anyRequest().permitAll()

--- a/src/main/java/kr/elroy/aigoya/store/domain/Store.java
+++ b/src/main/java/kr/elroy/aigoya/store/domain/Store.java
@@ -46,6 +46,12 @@ public class Store {
     @Column(name = "dailyTarget")
     private Long dailyTarget;
 
+    @Column(name = "nx")
+    private Integer nx;
+
+    @Column(name = "ny")
+    private Integer ny;
+
     @OneToMany(mappedBy = "store", orphanRemoval = true)
     private List<Order> orders = new ArrayList<>();
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,3 +7,8 @@ spring:
       chat:
         options:
           model: gpt-4.1-nano-2025-04-14
+
+kma:
+  api:
+    service-key: ${KMA_API_SERVICE_KEY}
+    url: "http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst"

--- a/src/main/resources/prompts/ai-router-prompt.st
+++ b/src/main/resources/prompts/ai-router-prompt.st
@@ -1,0 +1,19 @@
+You are a smart AI router for a store owner. Your primary job is to analyze the user's request and select all the appropriate tools to handle it. You must not answer the user's question directly.
+
+Here are the available tools:
+- "generateSalesReport": Use this tool when the user asks for sales reports, performance, revenue, or earnings. Example: "어제 매출 알려줘", "월간 보고서 만들어줘"
+- "predictInventory": Use this tool when the user asks about inventory, stock, or predictions. Example: "재고 예측해줘", "곧 떨어질 메뉴가 뭐야?"
+- "generateMarketingCopy": Use this tool when the user asks for marketing messages, promotions, or advertisements. Example: "단골 손님에게 보낼 할인 메시지 만들어줘"
+- "analyzeSalesByWeather": Use this tool when the user asks for sales analysis, trends, or correlations with external factors like weather. Example: "비 오는 날 뭐가 잘 팔려?", "날씨랑 매출 관계 좀 분석해줘"
+- "getWeather": Use this tool when the user asks directly about the current or future weather. Example: "오늘 날씨 어때?", "내일 비 와?"
+
+Based on the conversation history and the user's latest message, you must decide which tool(s) to use.
+
+- If you decide to use one or more tools, respond with ONLY the tool names, separated by commas. For example: "generateSalesReport,predictInventory".
+- If no specific tool is suitable for the request and a general conversation is needed, respond with "CHAT".
+
+Do not add any other text, explanation, or punctuation.
+
+<Conversation History>
+{chatHistory}
+</Conversation History>

--- a/src/main/resources/prompts/final-synthesis-prompt.st
+++ b/src/main/resources/prompts/final-synthesis-prompt.st
@@ -1,0 +1,14 @@
+You are a highly capable AI assistant for a store owner. Your task is to synthesize the results from various tools into a single, coherent, and user-friendly report.
+
+Here is the recent conversation history for context:
+<Conversation History>
+{chatHistory}
+</Conversation History>
+
+Here are the results from the tools that were executed based on the user's request:
+<Tool Results>
+{toolResults}
+</Tool Results>
+
+Based on all this information, please provide a comprehensive and easy-to-understand final response to the user.
+Your response must be in Korean and should naturally integrate all the information from the tool results.

--- a/src/main/resources/prompts/history-summary-prompt.st
+++ b/src/main/resources/prompts/history-summary-prompt.st
@@ -1,0 +1,14 @@
+You are an expert conversation analyst. Your task is to read the following conversation and extract only the essential information needed for another AI to continue the conversation without losing context.
+
+Focus on extracting these key points:
+1. The user's most recent and primary question or request.
+2. Any specific conditions, constraints, or data mentioned by the user (e.g., specific dates, product names, requests to exclude something).
+3. The core message of the AI's last response if it contains a suggestion or key information.
+
+Condense these points into a brief summary. The summary should be dense with facts.
+
+<Conversation History>
+{chatHistory}
+</Conversation History>
+
+Your summary must be in Korean.

--- a/src/main/resources/prompts/inventory-prediction.st
+++ b/src/main/resources/prompts/inventory-prediction.st
@@ -1,6 +1,11 @@
-당신은 매장 관리 도우미 AI입니다.
-아래 매출 데이터를 기반으로 향후 3일 내 부족할 가능성이 있는 재고를 예측하세요.
-간단히 품목별 발주 권장량을 제안하세요.
+You are a helpful AI assistant for a store owner.
+Your task is to predict inventory needs based on sales data.
 
-매출 데이터:
+Here is the recent conversation history for context:
+{chatHistory}
+
+Here is the sales data for the store:
 {salesData}
+
+Based on the conversation history and the sales data, predict which items might run out soon or need reordering.
+Your response must be in Korean.

--- a/src/main/resources/prompts/marketing-copy.st
+++ b/src/main/resources/prompts/marketing-copy.st
@@ -1,11 +1,14 @@
-당신은 소상공인 카페 혹은 레스토랑의 마케팅 전문가입니다.
-사장님의 요청과 판매 데이터를 바탕으로 친근하고 효과적인 마케팅 메시지를 작성하는 것이 당신의 임무입니다.
+You are a marketing expert for a small cafe or restaurant.
+Your task is to create a friendly and effective marketing message based on the owner's request and sales data.
 
-가게의 판매 데이터는 다음과 같습니다:
+Here is the recent conversation history for context:
+{chatHistory}
+
+Here is the sales data for the store:
 {salesData}
 
-이 데이터를 바탕으로, 아래 사장님의 요청에 맞는 짧고 매력적인 마케팅 메시지(문자 혹은 푸시 알림 형식)를 작성해 주세요.
-사장님의 요청: {request}
+Based on the conversation history, sales data, and the owner's latest request, please write a short, appealing marketing message (SMS or push notification style).
+Owner's Request: {request}
 
-메시지를 자연스럽고 친근한 말투로 작성해 주세요. 사장님의 요청을 그대로 옮겨 적지 마세요.
-답변은 반드시 한국어로 작성해야 합니다.
+Make the message sound natural and inviting. Do not just repeat the request.
+Your response must be in Korean.

--- a/src/main/resources/prompts/sales-analysis-by-weather-prompt.st
+++ b/src/main/resources/prompts/sales-analysis-by-weather-prompt.st
@@ -1,0 +1,15 @@
+You are an expert data analyst specializing in retail sales. Your task is to analyze the relationship between weather conditions and product sales based on the provided data, and report the findings to the store owner in an easy-to-understand way.
+
+The data format is a series of lines, each representing a product sold in an order:
+`날짜: [YYYY-MM-DD], 날씨: [Weather], 상품: [Product Name], 수량: [Quantity]`
+
+<Data>
+{salesAndWeatherData}
+</Data>
+
+Based on the data above, please perform the following analysis:
+1.  Identify any products that show a significant increase or decrease in sales on specific weather days (e.g., "rainy", "sunny", "cloudy").
+2.  Provide specific examples from the data to support your findings.
+3.  Summarize the key insights into actionable advice for the store owner. For example, "On rainy days, you should consider preparing more stock of [Product A] as its sales tend to increase."
+
+Present your final report in Korean, in a clear and friendly tone suitable for a store owner.

--- a/src/main/resources/prompts/sales-report.st
+++ b/src/main/resources/prompts/sales-report.st
@@ -1,6 +1,11 @@
-당신은 매장 관리 도우미 AI입니다.
-아래 매출 데이터를 바탕으로 직원이 이해하기 쉬운 요약 보고서를 작성하세요.
-추가로 매출의 이윤을 극대화할 방안(인터넷 검색을 통해 실제로 어울리는 조합인지 판단 후 추천 등)도 알려주세요.
+You are a helpful AI assistant for a store owner.
+Your task is to generate a sales report based on the provided data.
 
-매출 데이터:
+Here is the recent conversation history for context:
+{chatHistory}
+
+Here is the sales data for the store:
 {salesData}
+
+Based on the conversation history and the sales data, generate a sales report that fulfills the user's latest request.
+Your response must be in Korean.


### PR DESCRIPTION
## 이 PR이 하는 일

가게 운영을 돕는 ai 비서 기능의 향상된 아키텍쳐 도입

## 설명
-Ai 에이전트의 아키텍처 도입
AgentService: 사용자의 의도를 파악 후 적절한 tool을 선택하는 router 기능을 지원

Aiservice: 실제 기능을 수행하는 tool의 모음

-대화 기록 관리
ChatMessage 엔티티에 사용자와 AI의 이전 대화의 맥락을 기억하는대 사용

단기 키워드 기억을 위한 historySummary를 도입해 최적화된 대답을 보냄

-날씨 기반 분석을 위한 기상청 API 도입
가게 정보에 날씨 조회를 위한 Store에 좌표 정보 추가(기본 좌표는 서울로 되어있음)

좌표를 통한 날씨 분석 후 매출 상품과 연관성을 파악하는 기능 추가

## 비고
**AI 비서 기능 테스트 방법**
1.Postman으로 로그인 API (POST /v1/stores/login)를 호출하여 accessToken을 발급받습니다.

2.AI 채팅 API (POST /api/ai/chat)를 호출합니다.

3.발급받은 accessToken을  Authorization: Bearer에 추가

4.Body에 테스트하고 싶은 질문을 담아 요청을 보냅니다.(여러 질문을 합쳐서 말해도 상관없음)

[매출 보고서 요청]
{
  "message": "지난주 매출 보고서 만들어줘."
}

[날씨 기반 분석 요청]
{
  "message": "비 오는 날에 잘 팔리는 메뉴가 뭐야?"
}

[단순 날씨 조회 요청]
{
  "message": "오늘 날씨 어때?"
}
    
[마케팅 문구 생성 요청]
{
  "message": "가장 인기 있는 메뉴로 할인 이벤트 하려는데, 손님들한테 보낼 문자 메시지 하나만 재밌게 써줘."
}


    
    

