### PR TITLE
feat: 직원의 고정 근무 요일 및 시간 관리 기능 추가

### DIFF
--- a/src/main/java/kr/elroy/aigoya/store/api/EmployeeApi.java
+++ b/src/main/java/kr/elroy/aigoya/store/api/EmployeeApi.java
@@ -1,16 +1,21 @@
 package kr.elroy.aigoya.store.api;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import kr.elroy.aigoya.store.config.CurrentStoreId;
 import kr.elroy.aigoya.store.dto.request.AddEmployeeRequest;
 import kr.elroy.aigoya.store.dto.response.EmployeeResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
 import java.util.List;
 
@@ -18,14 +23,20 @@ import java.util.List;
 @RequestMapping("/v1/stores/me/employees")
 public interface EmployeeApi {
 
+    @Operation(summary = "직원 등록")
     @PostMapping
-    EmployeeResponse addEmployee(
+    @ResponseStatus(HttpStatus.CREATED)
+    EmployeeResponse createEmployee(
             @Parameter(hidden = true)
             @CurrentStoreId
             Long storeId,
-            @RequestBody AddEmployeeRequest request
+
+            @Valid
+            @RequestBody
+            AddEmployeeRequest request
     );
 
+    @Operation(summary = "직원 목록 조회")
     @GetMapping
     List<EmployeeResponse> getEmployees(
             @Parameter(hidden = true)
@@ -33,11 +44,33 @@ public interface EmployeeApi {
             Long storeId
     );
 
-    @DeleteMapping("/{employeeId}")
-    void removeEmployee(
-            @Parameter(hidden = true)
+    @Operation(summary = "직원 정보 수정")
+    @PutMapping("/{employeeId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    void updateEmployee(
             @CurrentStoreId
+            @Parameter(hidden = true)
             Long storeId,
-            @PathVariable Long employeeId
+
+            @Parameter(description = "수정할 직원의 ID", required = true)
+            @PathVariable
+            Long employeeId,
+
+            @Valid
+            @RequestBody
+            AddEmployeeRequest request
+    );
+
+    @Operation(summary = "직원 삭제")
+    @DeleteMapping("/{employeeId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    void removeEmployee(
+            @CurrentStoreId
+            @Parameter(hidden = true)
+            Long storeId,
+
+            @Parameter(description = "삭제할 직원의 ID", required = true)
+            @PathVariable
+            Long employeeId
     );
 }

--- a/src/main/java/kr/elroy/aigoya/store/controller/EmployeeController.java
+++ b/src/main/java/kr/elroy/aigoya/store/controller/EmployeeController.java
@@ -17,18 +17,13 @@ public class EmployeeController implements EmployeeApi {
     private final EmployeeService employeeService;
 
     @Override
-    public EmployeeResponse addEmployee(
-            Long storeId,
-            AddEmployeeRequest request
-    ) {
-        Employee employee = employeeService.addEmployee(storeId, request);
+    public EmployeeResponse createEmployee(Long storeId, AddEmployeeRequest request) {
+        Employee employee = employeeService.createEmployee(storeId, request);
         return EmployeeResponse.of(employee);
     }
 
     @Override
-    public List<EmployeeResponse> getEmployees(
-            Long storeId
-    ) {
+    public List<EmployeeResponse> getEmployees(Long storeId) {
         List<Employee> employees = employeeService.getEmployees(storeId);
         return employees.stream()
                 .map(EmployeeResponse::of)
@@ -36,10 +31,12 @@ public class EmployeeController implements EmployeeApi {
     }
 
     @Override
-    public void removeEmployee(
-            Long storeId,
-            Long employeeId
-    ) {
+    public void updateEmployee(Long storeId, Long employeeId, AddEmployeeRequest request) {
+        employeeService.updateEmployee(storeId, employeeId, request);
+    }
+
+    @Override
+    public void removeEmployee(Long storeId, Long employeeId) {
         employeeService.removeEmployee(storeId, employeeId);
     }
 }

--- a/src/main/java/kr/elroy/aigoya/store/domain/Employee.java
+++ b/src/main/java/kr/elroy/aigoya/store/domain/Employee.java
@@ -1,6 +1,7 @@
 package kr.elroy.aigoya.store.domain;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -8,6 +9,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import kr.elroy.aigoya.store.domain.converter.DayOfWeekSetConverter;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,7 +17,9 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.Set;
 
 @Entity
 @Getter
@@ -35,23 +39,29 @@ public class Employee {
     @Column(nullable = false)
     private String role;
 
-    @Column
-    private LocalDateTime checkInTime;
-
     @Column(nullable = false)
     private Integer hourlyWage;
+
+    @Column
+    private LocalTime workStartTime;
+
+    @Column
+    private LocalTime workEndTime;
+
+    @Column(name = "work_days", length = 100)
+    @Convert(converter = DayOfWeekSetConverter.class)
+    private Set<DayOfWeek> workDays;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "store_id", nullable = false)
     private Store store;
 
-    public void checkIn(LocalDateTime time) {
-        this.checkInTime = time;
-    }
-
-    public void updateInfo(String name, String role, Integer hourlyWage) {
+    public void updateInfo(String name, String role, Integer hourlyWage, LocalTime workStartTime, LocalTime workEndTime, Set<DayOfWeek> workDays) {
         this.name = name;
         this.role = role;
         this.hourlyWage = hourlyWage;
+        this.workStartTime = workStartTime;
+        this.workEndTime = workEndTime;
+        this.workDays = workDays;
     }
 }

--- a/src/main/java/kr/elroy/aigoya/store/domain/converter/DayOfWeekSetConverter.java
+++ b/src/main/java/kr/elroy/aigoya/store/domain/converter/DayOfWeekSetConverter.java
@@ -1,0 +1,37 @@
+package kr.elroy.aigoya.store.domain.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.time.DayOfWeek;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Converter
+public class DayOfWeekSetConverter implements AttributeConverter<Set<DayOfWeek>, String> {
+
+    private static final String DELIMITER = ",";
+
+    @Override
+    public String convertToDatabaseColumn(Set<DayOfWeek> attribute) {
+        if (attribute == null || attribute.isEmpty()) {
+            return "";
+        }
+        return attribute.stream()
+                .map(DayOfWeek::name)
+                .sorted()
+                .collect(Collectors.joining(DELIMITER));
+    }
+
+    @Override
+    public Set<DayOfWeek> convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.trim().isEmpty()) {
+            return Collections.emptySet();
+        }
+        return Arrays.stream(dbData.split(DELIMITER))
+                .map(DayOfWeek::valueOf)
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/kr/elroy/aigoya/store/dto/request/AddEmployeeRequest.java
+++ b/src/main/java/kr/elroy/aigoya/store/dto/request/AddEmployeeRequest.java
@@ -3,7 +3,11 @@ package kr.elroy.aigoya.store.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
+
+import java.time.DayOfWeek;
+import java.util.Set;
 
 @Schema(description = "직원 정보 요청 (추가/수정)")
 public record AddEmployeeRequest(
@@ -18,6 +22,17 @@ public record AddEmployeeRequest(
         @NotNull(message = "시급은 필수입니다.")
         @Positive(message = "시급은 0보다 커야 합니다.")
         @Schema(description = "시급 (원 단위)", example = "10000")
-        Integer hourlyWage
+        Integer hourlyWage,
+
+        @Pattern(regexp = "^([01]\\d|2[0-3]):([0-5]\\d)$", message = "근무 시작 시간은 HH:mm 형식이어야 합니다.")
+        @Schema(description = "근무 시작 시간 (HH:mm)", example = "09:00")
+        String workStartTime,
+
+        @Pattern(regexp = "^([01]\\d|2[0-3]):([0-5]\\d)$", message = "근무 종료 시간은 HH:mm 형식이어야 합니다.")
+        @Schema(description = "근무 종료 시간 (HH:mm)", example = "18:00")
+        String workEndTime,
+
+        @Schema(description = "근무 요일 목록", example = "[\"MONDAY\", \"TUESDAY\", \"WEDNESDAY\"]")
+        Set<DayOfWeek> workDays
 ) {
 }

--- a/src/main/java/kr/elroy/aigoya/store/dto/response/EmployeeResponse.java
+++ b/src/main/java/kr/elroy/aigoya/store/dto/response/EmployeeResponse.java
@@ -2,7 +2,11 @@ package kr.elroy.aigoya.store.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import kr.elroy.aigoya.store.domain.Employee;
-import java.time.LocalDateTime;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Set;
 
 @Schema(description = "직원 정보 응답")
 public record EmployeeResponse(
@@ -15,20 +19,37 @@ public record EmployeeResponse(
         @Schema(description = "직책", example = "파트타이머")
         String role,
 
-        @Schema(description = "마지막 출근 시간", example = "2025-08-17T09:00:00")
-        LocalDateTime checkInTime,
-
         @Schema(description = "시급 (원 단위)", example = "10000")
-        Integer hourlyWage
+        Integer hourlyWage,
+
+        @Schema(description = "근무 시작 시간 (HH:mm)", example = "09:00")
+        String workStartTime,
+
+        @Schema(description = "근무 종료 시간 (HH:mm)", example = "18:00")
+        String workEndTime,
+
+        @Schema(description = "근무 요일 목록", example = "[\"MONDAY\", \"TUESDAY\"]")
+        Set<DayOfWeek> workDays
 ) {
+
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
 
     public static EmployeeResponse of(Employee employee) {
         return new EmployeeResponse(
                 employee.getId(),
                 employee.getName(),
                 employee.getRole(),
-                employee.getCheckInTime(),
-                employee.getHourlyWage()
+                employee.getHourlyWage(),
+                formatTime(employee.getWorkStartTime()),
+                formatTime(employee.getWorkEndTime()),
+                employee.getWorkDays()
         );
+    }
+
+    private static String formatTime(LocalTime time) {
+        if (time == null) {
+            return null;
+        }
+        return time.format(TIME_FORMATTER);
     }
 }

--- a/src/main/java/kr/elroy/aigoya/store/repository/EmployeeRepository.java
+++ b/src/main/java/kr/elroy/aigoya/store/repository/EmployeeRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 public interface EmployeeRepository extends JpaRepository<Employee, Long> {
 
     List<Employee> findByStore(Store store);
+
+    List<Employee> findByStoreId(Long storeId);
 }


### PR DESCRIPTION
## 이 PR이 하는 일
feat: 직원의 고정 근무 요일 및 시간 관리 기능 추가

## 설명

본문기존의 단순 출퇴근 시간 기록 방식에서 벗어나, 가게 주인이 각 직원의 고정된 근무 스케줄을 체계적으로 관리할 수 있도록 직원 관리 기능을 대폭 개선했습니다.
이제 각 직원별로 근무 요일과 근무 시간을 명확하게 설정하고 조회할 수 있어, 주간 스케줄 관리 및 급여 정산의 기반을 마련했습니다.

## 구현된 기능
•고정 근무 스케줄 설정:
    •직원을 등록하거나 수정할 때, **근무 시작 시간(HH:mm)**과 **종료 시간(HH:mm)**을 설정할 수 있습니다.
    •일주일 중 근무하는 요일을 복수 선택하여 지정할 수 있습니다. (예: 월, 수, 금)
    •근무 스케줄 조회:•직원 목록 또는 개별 직원 조회 시, 설정된 근무 시간과 요일 정보가 함께 반환됩니다.
## 아키텍처 변경 사항
•Employee 엔티티 모델 변경:
    •기존의 checkInTime: LocalDateTime 필드를 삭제했습니다.
    •workStartTime: LocalTime, workEndTime: LocalTime 필드를 추가하여 근무 시간을 명확히 표현했습니다.
    •workDays: Set<DayOfWeek> 필드를 추가하여 여러 개의 근무 요일을 유연하게 관리할 수 있도록 했습니다.
•AttributeConverter 도입:
    •자바의 Set<DayOfWeek> 타입을 데이터베이스의 VARCHAR 컬럼에 쉼표로 구분된 문자열(예: "MONDAY,TUESDAY")로 저장하기 위해, JPA 표준 기능인 DayOfWeekSetConverter를 구현하고 적용했습니다.
    •이를 통해 서비스 로직에서는 데이터베이스의 저장 형태를 신경 쓸 필요 없이, 객체 지향적인 Set 자료구조를 그대로 사용할 수 있게 되어 코드의 가독성과 유지보수성이 향상되었습니다.
    •DTO 및 서비스 로직 수정:•변경된 엔티티 모델에 맞춰 API의 요청/응답 DTO(AddEmployeeRequest, EmployeeResponse)를 전면 수정했습니다.
    •EmployeeService에 직원을 수정하는 updateEmployee 로직을 추가하고, 문자열로 받은 시간 데이터를 LocalTime 객체로 파싱하여 엔티티에 저장하는 등, 새로운 근무 스케줄을 처리하기 위한 비즈니스 로직을 구현했습니다.